### PR TITLE
Add Hosted Zone to terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ viewer2
 src/app-frontend/sass-bak/
 
 data/*
+terraform.tfstate*

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -4,7 +4,7 @@ docker_compose_version: "1.9.0"
 
 shellcheck_version: "0.3.*"
 
-terraform_version: "0.8.2"
+terraform_version: "0.9.11"
 
 aws_profile: "geotrellis"
 aws_cli_version: "1.11.30"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,5 +1,5 @@
 - src: azavea.pip
-  version: 0.1.1
+  version: 1.0.0
 
 - src: azavea.docker
   version: 2.2.0

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -134,8 +134,8 @@ data "template_file" "app_server_http_ecs_task" {
   template = "${file("task-definitions/app-server.json")}"
 
   vars {
-    nginx_image_url      = "${var.nginx_image}"
-    api_server_image_url = "${var.api_server_image}"
+    nginx_image_url      = "279682201306.dkr.ecr.us-east-1.amazonaws.com/rastervision-nginx:${var.image_version}"
+    api_server_image_url = "279682201306.dkr.ecr.us-east-1.amazonaws.com/rastervision-api-server:${var.image_version}"
     region               = "${var.aws_region}"
     environment          = "${var.environment}"
   }

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+terraform {
+  backend "s3" {
+    region  = "us-east-1"
+    encrypt = "true"
+  }
+}

--- a/deployment/terraform/container-service.tf
+++ b/deployment/terraform/container-service.tf
@@ -4,7 +4,6 @@
 
 # ECS cluster is only a name that ECS machines may join
 resource "aws_ecs_cluster" "container_instance" {
-
   lifecycle {
     create_before_destroy = true
   }
@@ -143,6 +142,7 @@ resource "aws_autoscaling_group" "ecs" {
   min_size                  = "${var.desired_instance_count}"
   max_size                  = "${var.desired_instance_count}"
   vpc_zone_identifier       = ["${module.vpc.private_subnet_ids}"]
+
   # vpc_zone_identifier       = ["${var.vpc_subnet_ids}"]
 
   tag {
@@ -150,13 +150,11 @@ resource "aws_autoscaling_group" "ecs" {
     value               = "${var.project_id}-ContainerInstance"
     propagate_at_launch = true
   }
-
   tag {
     key                 = "Project"
     value               = "${var.project}"
     propagate_at_launch = true
   }
-
   tag {
     key                 = "Environment"
     value               = "${var.environment}"

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -1,0 +1,18 @@
+#
+# Route 53 Resources
+#
+resource "aws_route53_zone" "external" {
+  name = "${var.route53_external_hosted_zone}"
+}
+
+resource "aws_route53_record" "server_app" {
+  zone_id = "${aws_route53_zone.external.id}"
+  name    = "${var.route53_external_hosted_zone}"
+  type    = "A"
+
+  alias {
+    name                   = "${lower(aws_alb.server_app.dns_name)}."
+    zone_id                = "${aws_alb.server_app.zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -66,6 +66,6 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_logs_policy_container_inst
 }
 
 resource "aws_iam_instance_profile" "container_instance" {
-  name  = "${aws_iam_role.container_instance_ec2.name}"
-  roles = ["${aws_iam_role.container_instance_ec2.name}"]
+  name = "${aws_iam_role.container_instance_ec2.name}"
+  role = "${aws_iam_role.container_instance_ec2.name}"
 }

--- a/deployment/terraform/provider.tf
+++ b/deployment/terraform/provider.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  region = "${var.aws_region}"
-}

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -3,18 +3,16 @@
 #
 # resource "aws_s3_bucket" "logs" {
 #   bucket = "rastervision-${lower(var.environment)}-logs-${var.aws_region}"
-
 #   tags {
 #     Project     = "${var.project}"
 #     Environment = "${var.environment}"
 #   }
 # }
-
 # resource "aws_s3_bucket" "catalogs" {
 #   bucket = "rastervision-${lower(var.environment)}-catalogs-${var.aws_region}"
-
 #   tags {
 #     Project     = "${var.project}"
 #     Environment = "${var.environment}"
 #   }
 # }
+

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -21,9 +21,7 @@ variable "aws_availability_zones" {
 variable "aws_key_name" {}
 
 # ECS
-
-variable "api_server_image" {}
-variable "nginx_image" {}
+variable "image_version" {}
 
 variable "desired_instance_count" {}
 variable aws_ecs_ami {}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -29,7 +29,6 @@ variable "desired_instance_count" {}
 variable aws_ecs_ami {}
 variable ecs_instance_type {}
 
-
 # IAM
 
 variable "aws_ecs_for_ec2_service_role_policy_arn" {
@@ -48,11 +47,11 @@ variable "aws_cloudwatch_logs_policy_arn" {
   default = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
 }
 
-
 # VPC
 
 variable vpc_cidr_block {}
 variable vpc_external_access_cidr_block {}
+
 variable "vpc_private_subnet_cidr_blocks" {
   default = ["10.0.1.0/24", "10.0.3.0/24"]
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -71,3 +71,9 @@ variable vpc_bastion_instance_type {}
 variable server_app_alb_ingress_cidr_block {
   default = ["0.0.0.0/0"]
 }
+
+# Route53
+
+variable "route53_external_hosted_zone" {
+  default = "potsdam.geotrellis.io."
+}

--- a/scripts/infra.sh
+++ b/scripts/infra.sh
@@ -46,7 +46,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
                 terraform plan \
                           -var-file="${RV_SETTINGS_BUCKET}.tfvars" \
-                          -var="git_commit=${GIT_COMMIT}" \
+                          -var="image_version=${GIT_COMMIT}" \
                           -out="${RV_SETTINGS_BUCKET}.tfplan"
                 ;;
             apply)


### PR DESCRIPTION
# Overview

Add the `potsdam.geotrellis.io` hosted zone and associated Route53 records to the Terraform configuration.

## Notable changes
- Add terraform 0.9 support
- Add Terraform resources for the `potsdam.geotrellis.io` external hosted zone and records.
- Simplify security group rules
    - The Container Instance security group is configured to allow all egress traffic. I removed any redundant egress rules.
    - The current security group configuration uses a combination of `aws_security_group` ingress/egress blocks, and `aws_security_group_rule` resources. Per the [Terraform docs](https://www.terraform.io/docs/providers/aws/r/security_group.html), this is not recommended, so I removed all of the `security_group_rule` blocks and added corresponding ingress/egress rules to the `aws_security_group`.  
- Pass the `nginx` and `api-server` image versions to Terraform through `scripts/infra` instead of hardcoding them. 

# Testing
```
$ vagrant provision
$ vagrant ssh
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ export RV_SETTINGS_BUCKET=rastervision-viz-staging-config-us-east-1
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ export GIT_COMMIT=ce8b3db
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ ./scripts/infra plan
```

Fixes #7 
