### PR TITLE
Add SSL certificate and serve over HTTPS

### DIFF
--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -60,7 +60,7 @@ resource "aws_alb_target_group" "server_app_https" {
     interval            = "30"
     protocol            = "HTTP"
     timeout             = "3"
-    path                = "/healthcheck/"
+    path                = "/"
     unhealthy_threshold = "2"
   }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -23,6 +23,10 @@ variable "aws_key_name" {}
 # ECS
 variable "image_version" {}
 
+variable "ssl_certificate_arn" {
+  default = "arn:aws:acm:us-east-1:279682201306:certificate/7c1d8d7e-b809-44a2-a835-5cdf5a0e9357"
+}
+
 variable "desired_instance_count" {}
 variable aws_ecs_ami {}
 variable ecs_instance_type {}
@@ -60,11 +64,6 @@ variable "vpc_public_subnet_cidr_blocks" {
 
 variable vpc_bastion_ami {}
 variable vpc_bastion_instance_type {}
-
-# variable vpc_id {}
-# variable vpc_subnet_ids {
-#   default = []
-# }
 
 variable server_app_alb_ingress_cidr_block {
   default = ["0.0.0.0/0"]

--- a/src/app-frontend/js/components/Map.jsx
+++ b/src/app-frontend/js/components/Map.jsx
@@ -327,23 +327,23 @@ export default class Map extends Component {
                 <ZoomControl position="topright" />
 
                 {/* <TileLayer
-                url="http://tile.stamen.com/terrain-background/{z}/{x}/{y}@2x.jpg"
+                url="https://stamen-tiles-{s}.a.ssl.fastly.net/terrain-background/{z}/{x}/{y}@2x.jpg"
                 /> */}
 
                 {/* <TileLayer
-                url="http://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png"
+                url="https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png"
                 /> */}
 
                 <TileLayer
-                    url="http://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png"
+                    url="https://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png"
                 />
 
                 {/* <TileLayer
-                url="http://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png"
+                url="https://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png"
                 /> */}
 
                 <TileLayer
-                    url="http://tile.stamen.com/toner-labels/{z}/{x}/{y}@2x.png"
+                    url="https://stamen-tiles-{s}.a.ssl.fastly.net/toner-labels/{z}/{x}/{y}@2x.png"
                 />
 
                 {layers}

--- a/static/index1.html
+++ b/static/index1.html
@@ -6,7 +6,7 @@
     <meta name="description" content="GeoTrellis features demo.">
     <meta name="author" content="Azavea">
 
-	 <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+	 <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link href="css/bootstrap.css" rel="stylesheet">
     <style type="text/css">
       body {
@@ -46,7 +46,7 @@
     <script src="js/leaflet-src.js"></script>
     <script src="js/leaflet.draw.js"></script>
     <script src="js/geojson.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
 
     <script src="js/jquery-1.11.3.min.js"></script>
     <script src="js/jquery-ui-1.10.0.min.js"></script>

--- a/static/index2.html
+++ b/static/index2.html
@@ -6,7 +6,7 @@
     <meta name="description" content="GeoTrellis features demo.">
     <meta name="author" content="Azavea">
 
-	 <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+	 <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link href="css/bootstrap.css" rel="stylesheet">
     <style type="text/css">
       body {
@@ -46,7 +46,7 @@
     <script src="js/leaflet-src.js"></script>
     <script src="js/leaflet.draw.js"></script>
     <script src="js/geojson.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
 
     <script src="js/jquery-1.11.3.min.js"></script>
     <script src="js/jquery-ui-1.10.0.min.js"></script>

--- a/static/index3.html
+++ b/static/index3.html
@@ -6,7 +6,7 @@
     <meta name="description" content="GeoTrellis features demo.">
     <meta name="author" content="Azavea">
 
-	 <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+	 <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link href="css/bootstrap.css" rel="stylesheet">
     <style type="text/css">
       body {
@@ -46,7 +46,7 @@
     <script src="js/leaflet-src.js"></script>
     <script src="js/leaflet.draw.js"></script>
     <script src="js/geojson.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
 
     <script src="js/jquery-1.11.3.min.js"></script>
     <script src="js/jquery-ui-1.10.0.min.js"></script>

--- a/static/index4.html
+++ b/static/index4.html
@@ -6,7 +6,7 @@
     <meta name="description" content="GeoTrellis features demo.">
     <meta name="author" content="Azavea">
 
-	 <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+	 <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link href="css/bootstrap.css" rel="stylesheet">
     <style type="text/css">
       body {
@@ -46,7 +46,7 @@
     <script src="js/leaflet-src.js"></script>
     <script src="js/leaflet.draw.js"></script>
     <script src="js/geojson.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
 
     <script src="js/jquery-1.11.3.min.js"></script>
     <script src="js/jquery-ui-1.10.0.min.js"></script>

--- a/static/index5.html
+++ b/static/index5.html
@@ -6,7 +6,7 @@
     <meta name="description" content="GeoTrellis features demo.">
     <meta name="author" content="Azavea">
 
-	 <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+	 <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link href="css/bootstrap.css" rel="stylesheet">
     <style type="text/css">
       body {
@@ -46,7 +46,7 @@
     <script src="js/leaflet-src.js"></script>
     <script src="js/leaflet.draw.js"></script>
     <script src="js/geojson.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4/underscore-min.js"></script>
 
     <script src="js/jquery-1.11.3.min.js"></script>
     <script src="js/jquery-ui-1.10.0.min.js"></script>

--- a/static/js/application.js
+++ b/static/js/application.js
@@ -7,15 +7,15 @@ var getLayer = function(url,attrib) {
 
 var Layers = {
   stamen: {
-    toner:  'http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png',
-    terrain: 'http://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png',
-    watercolor: 'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png',
+    toner:  'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
+    terrain: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+    watercolor: 'https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.png',
     attrib: 'Map data &copy;2013 OpenStreetMap contributors, Tiles &copy;2013 Stamen Design'
   },
   mapBox: {
-    azavea:     'http://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
-    worldLight: 'http://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
-    attrib: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">MapBox</a>'
+    azavea:     'https://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
+    worldLight: 'https://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
+    attrib: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="https://mapbox.com">MapBox</a>'
   }
 };
 

--- a/static/js/application1.js
+++ b/static/js/application1.js
@@ -6,15 +6,15 @@ var getLayer = function(url,attrib) {
 
 var Layers = {
   stamen: {
-    toner:  'http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png',
-    terrain: 'http://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png',
-    watercolor: 'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png',
+    toner:  'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
+    terrain: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+    watercolor: 'https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.png',
     attrib: 'Map data &copy;2013 OpenStreetMap contributors, Tiles &copy;2013 Stamen Design'
   },
   mapBox: {
-    azavea:     'http://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
-    worldLight: 'http://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
-    attrib: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">MapBox</a>'
+    azavea:     'https://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
+    worldLight: 'https://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
+    attrib: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="https://mapbox.com">MapBox</a>'
   }
 };
 

--- a/static/js/application2.js
+++ b/static/js/application2.js
@@ -6,15 +6,15 @@ var getLayer = function(url,attrib) {
 
 var Layers = {
   stamen: {
-    toner:  'http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png',
-    terrain: 'http://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png',
-    watercolor: 'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png',
+    toner:  'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
+    terrain: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+    watercolor: 'https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.png',
     attrib: 'Map data &copy;2013 OpenStreetMap contributors, Tiles &copy;2013 Stamen Design'
   },
   mapBox: {
-    azavea:     'http://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
-    worldLight: 'http://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
-    attrib: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">MapBox</a>'
+    azavea:     'https://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
+    worldLight: 'https://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
+    attrib: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="https://mapbox.com">MapBox</a>'
   }
 };
 

--- a/static/js/application3.js
+++ b/static/js/application3.js
@@ -18,15 +18,15 @@ var getLayer = function(url,attrib) {
 
 var Layers = {
   stamen: {
-    toner:  'http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png',
-    terrain: 'http://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png',
-    watercolor: 'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png',
+    toner:  'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
+    terrain: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+    watercolor: 'https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.png',
     attrib: 'Map data &copy;2013 OpenStreetMap contributors, Tiles &copy;2013 Stamen Design'
   },
   mapBox: {
-    azavea:     'http://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
-    worldLight: 'http://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
-    attrib: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">MapBox</a>'
+    azavea:     'https://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
+    worldLight: 'https://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
+    attrib: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="https://mapbox.com">MapBox</a>'
   }
 };
 

--- a/static/js/application4.js
+++ b/static/js/application4.js
@@ -18,15 +18,15 @@ var getLayer = function(url,attrib) {
 
 var Layers = {
   stamen: {
-    toner:  'http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png',
-    terrain: 'http://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png',
-    watercolor: 'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png',
+    toner:  'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
+    terrain: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+    watercolor: 'https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.png',
     attrib: 'Map data &copy;2013 OpenStreetMap contributors, Tiles &copy;2013 Stamen Design'
   },
   mapBox: {
-    azavea:     'http://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
-    worldLight: 'http://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
-    attrib: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">MapBox</a>'
+    azavea:     'https://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
+    worldLight: 'https://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
+    attrib: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="https://mapbox.com">MapBox</a>'
   }
 };
 

--- a/static/js/application5.js
+++ b/static/js/application5.js
@@ -18,15 +18,15 @@ var getLayer = function(url,attrib) {
 
 var Layers = {
   stamen: {
-    toner:  'http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png',
-    terrain: 'http://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png',
-    watercolor: 'http://{s}.tile.stamen.com/watercolor/{z}/{x}/{y}.png',
+    toner:  'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png',
+    terrain: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
+    watercolor: 'https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.png',
     attrib: 'Map data &copy;2013 OpenStreetMap contributors, Tiles &copy;2013 Stamen Design'
   },
   mapBox: {
-    azavea:     'http://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
-    worldLight: 'http://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
-    attrib: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="http://mapbox.com">MapBox</a>'
+    azavea:     'htts://{s}.tiles.mapbox.com/v3/azavea.map-zbompf85/{z}/{x}/{y}.png',
+    worldLight: 'https://c.tiles.mapbox.com/v3/mapbox.world-light/{z}/{x}/{y}.png',
+    attrib: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery &copy; <a href="https://mapbox.com">MapBox</a>'
   }
 };
 


### PR DESCRIPTION
# Overview

Add an SSL certificate and HTTPS listeners to the ALB so it can serve the application over HTTPS.

## Notable changes
- Replace ALB `HTTP` ingress rules with `HTTPS` rules
- Replace ALB `HTTP` target groups/listeners with `HTTPS`
- Attach SSL certificate to ALB
- Request all tiles over HTTPS

# Testing
- see https://potsdam.geotrellis.io
- Run `scripts/infra.sh plan`, ensure no changes are necessary
```bash
$ vagrant ssh
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ export RV_SETTINGS_BUCKET=rastervision-viz-staging-config-us-east-1
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ export GIT_COMMIT=ce8b3db
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ ./scripts/infra.sh plan
```

Fixes #8 

