### PR TITLE
Allow terraform to set ECS ASG Name

### DIFF
--- a/deployment/terraform/container-service.tf
+++ b/deployment/terraform/container-service.tf
@@ -76,7 +76,7 @@ resource "aws_launch_configuration" "ecs" {
     create_before_destroy = true
   }
 
-  name                        = "ECS ${aws_ecs_cluster.container_instance.name}"
+  name_prefix                 = "ECS ${aws_ecs_cluster.container_instance.name}-"
   image_id                    = "${var.aws_ecs_ami}"
   instance_type               = "${var.ecs_instance_type}"
   key_name                    = "${var.aws_key_name}"


### PR DESCRIPTION
# Overview

Instead of setting the Launch Config name, set the name-prefix and allow terraform generate its own name. Fixes an issue where updating the Launch Config  throws a `Resource Already Exists` error. See https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#using-with-autoscaling-groups for more details.

# Testing
This has been deployed to Staging already as a part of #12. See the updated Launch Config name in the R&D account [AWS Console](https://us-east-1.console.aws.amazon.com/ec2/autoscaling/home?region=us-east-1#LaunchConfigurations:id=ECS+RV-ecsStagingCluster-00b642b3c4deebde6abc4fdf1f).

Closes #12 