### PR TITLE
Remove default value for ssl_certificate_arn

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -12,8 +12,7 @@ Amazon Web Services deployment is driven by [Terraform](https://terraform.io/) a
 Using the AWS CLI, create an AWS profile named `geotrellis`:
 
 ```bash
-$ vagrant ssh
-vagrant@vagrant-ubuntu-trusty-64:~$ aws --profile geotrellis configure
+$ aws --profile geotrellis configure
 AWS Access Key ID [********************]:
 AWS Secret Access Key [********************]:
 Default region name [us-east-1]: us-east-1
@@ -27,16 +26,17 @@ You will be prompted to enter your AWS credentials, along with a default region.
 Next, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
 
 ```bash
-vagrant@vagrant-ubuntu-trusty-64:~$ export PGW_COMMUNITY_MAPPING_SETTINGS_BUCKET="staging-pgw-cm-config-us-east-1"
-vagrant@vagrant-ubuntu-trusty-64:~$ export PGW_COMMUNITY_MAPPING_SITE_BUCKET="staging-pgw-cm-site-us-east-1"
-vagrant@vagrant-ubuntu-trusty-64:~$ export AWS_PROFILE="geotrellis"
-vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/infra.sh plan
+$ export POTSDAM_SETTINGS_BUCKET="geotrellis-site-production-config-us-east-1"
+$ export AWS_PROFILE="geotrellis"
+# TRAVIS_COMMIT is the 7-digit SHA for the commit you want to deploy
+$ export TRAVIS_COMMIT=1a3b5c7
+$ docker-compose -f docker-compose.ci.yml -f docker-compose.ci.override.yml run --rm terraform ./scripts/infra.sh plan
 ```
 
 Once the plan has been assembled, and you agree with the changes, apply it:
 
 ```bash
-vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/infra.sh apply
+$ docker-compose -f docker-compose.ci.yml -f docker-compose.ci.override.yml run --rm terraform ./scripts/infra.sh apply
 ```
 
 This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -22,6 +22,10 @@ resource "aws_cloudwatch_log_group" "potsdam" {
   }
 }
 
+data "aws_iam_role" "autoscaling" {
+  role_name = "${var.ecs_autoscaling_role_name}"
+}
+
 module "potsdam_ecs_service" {
   source = "github.com/azavea/terraform-aws-ecs-web-service?ref=0.2.0"
 
@@ -44,7 +48,7 @@ module "potsdam_ecs_service" {
   container_port                 = "443"
   health_check_path              = "/"
   ecs_service_role_name          = "${data.terraform_remote_state.core.ecs_service_role_name}"
-  ecs_autoscale_role_arn         = "${data.terraform_remote_state.core.ecs_autoscale_role_arn}"
+  ecs_autoscale_role_arn         = "${data.aws_iam_role.autoscaling.arn}"
 
   project     = "Potsdam Demo"
   environment = "${var.environment}"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -15,6 +15,7 @@ variable "aws_region" {
 variable "aws_account_id" {
   default = "896538046175"
 }
+
 variable "remote_state_bucket" {
   default = "geotrellis-site-production-config-us-east-1"
 }
@@ -23,6 +24,10 @@ variable "remote_state_bucket" {
 variable "image_version" {}
 
 variable "ssl_certificate_arn" {}
+
+variable "ecs_autoscaling_role_name" {
+  default = "AWSServiceRoleForApplicationAutoScaling_ECSService"
+}
 
 variable "potsdam_ecs_desired_count" {
   default = "1"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -22,9 +22,7 @@ variable "remote_state_bucket" {
 # ECS
 variable "image_version" {}
 
-variable "ssl_certificate_arn" {
-  default = "arn:aws:acm:us-east-1:896538046175:certificate/a416c2af-00dd-4afd-8c71-dd32edefa839"
-}
+variable "ssl_certificate_arn" {}
 
 variable "potsdam_ecs_desired_count" {
   default = "1"

--- a/docker-compose.ci.override.yml
+++ b/docker-compose.ci.override.yml
@@ -1,0 +1,13 @@
+version: '2.1'
+services:
+  terraform:
+    image: "quay.io/azavea/terraform:0.9.11"
+    volumes:
+      - ~/.aws:/root/.aws
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ECR_ENDPOINT=${AWS_ECR_ENDPOINT}
+    working_dir: /usr/local/src
+    entrypoint: bash

--- a/scripts/infra.sh
+++ b/scripts/infra.sh
@@ -38,12 +38,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         case "${1}" in
             plan)
                 rm -rf .terraform terraform.tfstate* 
+                aws s3 cp "s3://${POTSDAM_SETTINGS_BUCKET}/terraform/potsdam/terraform.tfvars" \
+                    "${POTSDAM_SETTINGS_BUCKET}.tfvars"
+
                 terraform init \
                   -backend-config="bucket=${POTSDAM_SETTINGS_BUCKET}" \
                   -backend-config="key=terraform/potsdam/state"
 
                 terraform plan \
                           -var="image_version=\"${TRAVIS_COMMIT}\"" \
+                          -var-file="${POTSDAM_SETTINGS_BUCKET}.tfvars" \
                           -out="${POTSDAM_SETTINGS_BUCKET}.tfplan"
                 ;;
             apply)


### PR DESCRIPTION
# Overview

This PR removes the default value for `ssl_certificate_arn` (which is now outdated) from `variables.tf`, and updates `scripts/infra` to use a .tfvars file to make it easier to override other defaults in the future.

## Changes
- Remove default value for `ssl_certficate_arn`
- Updated `scripts/infra.sh` to use a `.tfvars` file.
- Replace references to our user-created ECS autoscaling role with the AWS-provided autoscaling service role.
- Add `docker-compose.ci.override.yml` to make it easier to run local deployments.
- Update deployment documentation

# Testing
- Follow the instructions in the deployment `README` to run `scripts/infra.sh plan`. Make sure no changes are necessary.
```bash
$ export AWS_PROFILE=geotrellis
$ export TRAVIS_COMMIT=$(git rev-parse --short master)
$ docker-compose -f docker-compose.ci.yml -f docker-compose.ci.override.yml run --rm terraform ./scripts/infra.sh plan
```

- Visit https://potsdam.geotrellis.io. Ensure that the certificate serial number matches the serial number from the ACM console: https://console.aws.amazon.com/acm/home?region=us-east-1#/?id=4704eab3-c3f9-47fc-9568-a70a0038cf60.

<img width="791" alt="screen shot 2018-07-12 at 10 44 45 am" src="https://user-images.githubusercontent.com/2507188/42640601-a80d3954-85c0-11e8-9a0e-b09d23be74fc.png">

<img width="471" alt="screen shot 2018-07-12 at 10 44 05 am" src="https://user-images.githubusercontent.com/2507188/42640611-ac938366-85c0-11e8-8ed2-240d369c5d15.png">




Fixes #17 