### PR TITLE
Remove AWS_PROFILE from docker-compose.ci.yml

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,12 +4,10 @@ services:
     image: "quay.io/azavea/terraform:0.9.11"
     volumes:
       - ./:/usr/local/src
-      - ~/.aws:/root/.aws
     environment:
       - POTSDAM_DEBUG=1
       - POTSDAM_SETTINGS_BUCKET=${POTSDAM_SETTINGS_BUCKET:-geotrellis-site-production-config-us-east-1}
       - TRAVIS_COMMIT=${TRAVIS_COMMIT:-latest}
-      - AWS_PROFILE=${AWS_PROFILE}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_ECR_ENDPOINT=${AWS_ECR_ENDPOINT}


### PR DESCRIPTION
# Overview

The [last Travis build](https://travis-ci.org/azavea/isprs-potsdam-viz/builds/403190348#L6488) failed with a `Profile not found` error because `AWS_PROFILE` was set to a blank string. This PR removes `AWS_PROFILE` from `docker-compose.ci.yml` so that Travis uses AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from the build environment.

# Testing
- See https://travis-ci.org/azavea/isprs-potsdam-viz/builds/403207152